### PR TITLE
Accept input directory as first parameter, default to .

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ You can customize the behavior of `repo-to-text` with the following options:
   repo-to-text --debug > debug_log.txt 2>&1
   ```
 
+- `input_dir`: Specify the directory to process. If not provided, the current directory (`.`) will be used. For example:
+
+  ```bash
+  repo-to-text /path/to/input_dir
+  ```
+
 ## Settings
 
 `repo-to-text` also supports configuration via a `.repo-to-text-settings.yaml` file. By default, the tool works without this file, but you can use it to customize what gets included in the final text file.

--- a/repo_to_text/main.py
+++ b/repo_to_text/main.py
@@ -254,6 +254,7 @@ def create_default_settings_file():
 
 def main():
     parser = argparse.ArgumentParser(description='Convert repository structure and contents to text')
+    parser.add_argument('input_dir', nargs='?', default='.', help='Directory to process')  # P3e87
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
     parser.add_argument('--output-dir', type=str, help='Directory to save the output file')
     parser.add_argument('--create-settings', action='store_true', help='Create default .repo-to-text-settings.yaml file')  # Новый аргумент
@@ -266,7 +267,7 @@ def main():
         create_default_settings_file()
         logging.debug('.repo-to-text-settings.yaml file created')
     else:
-        save_repo_to_text(output_dir=args.output_dir)
+        save_repo_to_text(path=args.input_dir, output_dir=args.output_dir)  # Pf5b7
     
     logging.debug('repo-to-text script finished')
 


### PR DESCRIPTION
Fixes #7

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kirill-markin/repo-to-text/issues/7?shareId=565af162-abaa-4695-b84a-c70db90a9cef).