### PR TITLE
Add aliases for repo-to-text and --create-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ After installation, you can use the `repo-to-text` command in your terminal. Nav
 repo-to-text
 ```
 
+or
+
+```bash
+flatten
+```
+
 This will create a file named `repo-to-text_YYYY-MM-DD-HH-MM-SS-UTC.txt` in the current directory with the text representation of the repository. The contents of this file will also be copied to your clipboard for easy sharing.
 
 ### Options
@@ -56,10 +62,16 @@ You can customize the behavior of `repo-to-text` with the following options:
   
   This will save the file in the specified output directory instead of the current directory.
 
-- `--create-settings`: Create a default `.repo-to-text-settings.yaml` file with predefined settings. This is useful if you want to start with a template settings file and customize it according to your needs. To create the default settings file, run the following command in your terminal:
+- `--create-settings` or `--init`: Create a default `.repo-to-text-settings.yaml` file with predefined settings. This is useful if you want to start with a template settings file and customize it according to your needs. To create the default settings file, run the following command in your terminal:
 
   ```bash
   repo-to-text --create-settings
+  ```
+
+  or
+
+  ```bash
+  repo-to-text --init
   ```
 
   This will create a file named `.repo-to-text-settings.yaml` in the current directory. If the file already exists, an error will be raised to prevent overwriting.

--- a/repo_to_text/main.py
+++ b/repo_to_text/main.py
@@ -256,7 +256,7 @@ def main():
     parser = argparse.ArgumentParser(description='Convert repository structure and contents to text')
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
     parser.add_argument('--output-dir', type=str, help='Directory to save the output file')
-    parser.add_argument('--create-settings', action='store_true', help='Create default .repo-to-text-settings.yaml file')  # Новый аргумент
+    parser.add_argument('--create-settings', '--init', action='store_true', help='Create default .repo-to-text-settings.yaml file')
     args = parser.parse_args()
 
     setup_logging(debug=args.debug)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     entry_points={
         'console_scripts': [
             'repo-to-text=repo_to_text.main:main',
+            'flatten=repo_to_text.main:main',
         ],
     },
     classifiers=[


### PR DESCRIPTION
Fixes #11

Add aliases for `repo-to-text` and `--create-settings`.

* **setup.py**
  - Add alias `flatten` for `repo-to-text` in `entry_points`.

* **repo_to_text/main.py**
  - Add alias `--init` for `--create-settings` in `argparse` setup.

* **README.md**
  - Update usage documentation to include alias `flatten` for `repo-to-text`.
  - Update usage documentation to include alias `--init` for `--create-settings`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kirill-markin/repo-to-text/issues/11?shareId=20d0ea18-922c-4fe8-b132-22d21ab840f9).