### PR TITLE
chore: Added package-lock.json to ignore-content in default settings

### DIFF
--- a/repo_to_text/cli/cli.py
+++ b/repo_to_text/cli/cli.py
@@ -38,6 +38,7 @@ def create_default_settings_file() -> None:
         ignore-content:
           - "README.md"
           - "LICENSE"
+          - "package-lock.json"
     """)
     with open('.repo-to-text-settings.yaml', 'w', encoding='utf-8') as f:
         f.write(default_settings)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,6 +48,7 @@ ignore-tree-and-content:
   - ".repo-to-text-settings.yaml"
 ignore-content:
   - "README.md"
+  - "package-lock.json"
 """
     }
 


### PR DESCRIPTION
This PR adds `package-lock.json` to the default ignore-content list in the `.repo-to-text-settings.yaml` file. The change helps prevent package-lock.json from dominating the output text when running repo-to-text, as this file is typically large and not relevant for code review or sharing purposes.

### Changes

- Added `package-lock.json` to the `ignore-content` list in the default settings template in `repo_to_text/cli/cli.py`

### Why

Package lock files like `package-lock.json` often contain thousands of lines of dependency information that:
1. Takes up the majority of the output space
2. Is rarely needed when sharing code with LLMs or colleagues 
3. Makes the output harder to navigate and review

This small change improves the default experience for JavaScript/Node.js projects by filtering out this verbose dependency information by default.