### PR TITLE
Add minimal handling for broken symlinks in generate_output_content

### DIFF
--- a/repo_to_text/core/core.py
+++ b/repo_to_text/core/core.py
@@ -427,6 +427,16 @@ def generate_output_content(
                 with open(file_path, 'rb') as f_bin:
                     binary_content: bytes = f_bin.read()
                 _add_chunk_to_output(binary_content.decode('latin1')) # Add decoded binary
+            except FileNotFoundError as e:
+                # Minimal handling for bad symlinks
+                if os.path.islink(file_path) and not os.path.exists(file_path):
+                    try:
+                        target = os.readlink(file_path)
+                    except OSError:
+                        target = ''
+                    _add_chunk_to_output(f"[symlink] -> {target}")
+                else:
+                    raise e
             
             _add_chunk_to_output('\n</content>\n')
 


### PR DESCRIPTION
I have been using this tool to look at filesystems for smaller embedded systems. Often times those systems will have symlinks that either make sense in a whole system or simply do not exist because they would normally be created at runtime.

Current behavior:
```
:~/.../stride$ repo-to-text 
2025-08-11 13:29:33,713 - ERROR - Error occurred: [Errno 2] No such file or directory: './symlink'
```

I could try to get rid of all the "bad symlinks" before running the tool, but that discards potentially useful information.

This PR offering a potential implementation that notes bad symlinks as:

```
<content full_path="./path/to/symlink>
[symlink] -> ./path/to/notexists
</content>
```

which maintains the information while dealing with the error.