### PR TITLE
Add --skip-binary option to CLI

### DIFF
--- a/repo_to_text/cli/cli.py
+++ b/repo_to_text/cli/cli.py
@@ -74,6 +74,11 @@ def parse_args() -> argparse.Namespace:
         help="List of files or directories to ignore in both tree and content sections. "
         "Supports wildcards (e.g., '*')."
     )
+    parser.add_argument(
+        '--skip-binary',
+        action='store_true',
+        help='Skip binary files in the output.'
+    )
     return parser.parse_args()
 
 def main() -> NoReturn:
@@ -95,7 +100,8 @@ def main() -> NoReturn:
                 path=args.input_dir,
                 output_dir=args.output_dir,
                 to_stdout=args.stdout,
-                cli_ignore_patterns=args.ignore_patterns
+                cli_ignore_patterns=args.ignore_patterns,
+                skip_binary=args.skip_binary
             )
 
         logging.debug('repo-to-text script finished')

--- a/repo_to_text/core/core.py
+++ b/repo_to_text/core/core.py
@@ -252,7 +252,8 @@ def save_repo_to_text(
         path: str = '.',
         output_dir: Optional[str] = None,
         to_stdout: bool = False,
-        cli_ignore_patterns: Optional[List[str]] = None
+        cli_ignore_patterns: Optional[List[str]] = None,
+        skip_binary: bool = False
     ) -> str:
     """Save repository structure and contents to a text file or multiple files."""
     # pylint: disable=too-many-locals
@@ -276,7 +277,8 @@ def save_repo_to_text(
         gitignore_spec,
         content_ignore_spec,
         tree_and_content_ignore_spec,
-        maximum_word_count_per_file
+        maximum_word_count_per_file,
+        skip_binary
     )
 
     if to_stdout:
@@ -350,7 +352,8 @@ def generate_output_content(
         gitignore_spec: Optional[PathSpec],
         content_ignore_spec: Optional[PathSpec],
         tree_and_content_ignore_spec: Optional[PathSpec],
-        maximum_word_count_per_file: Optional[int] = None
+        maximum_word_count_per_file: Optional[int] = None,
+        skip_binary: bool = False
     ) -> List[str]:
     """Generate the output content for the repository, potentially split into segments."""
     # pylint: disable=too-many-arguments
@@ -423,10 +426,14 @@ def generate_output_content(
                     file_content = f.read()
                 _add_chunk_to_output(file_content)
             except UnicodeDecodeError:
-                logging.debug('Handling binary file contents: %s', file_path)
-                with open(file_path, 'rb') as f_bin:
-                    binary_content: bytes = f_bin.read()
-                _add_chunk_to_output(binary_content.decode('latin1')) # Add decoded binary
+                if skip_binary:
+                    _add_chunk_to_output("binary content skipped")
+                    continue
+                else:
+                    logging.debug('Handling binary file contents: %s', file_path)
+                    with open(file_path, 'rb') as f_bin:
+                        binary_content: bytes = f_bin.read()
+                    _add_chunk_to_output(binary_content.decode('latin1')) # Add decoded binary
             
             _add_chunk_to_output('\n</content>\n')
 


### PR DESCRIPTION
I find that there are cases where the only content I want from a repository is text-based. This is particularly important in repositories that contain large binary data which can overwhelm LLMs.

It is possible to ignore patterns for all those files, but I find that somewhat tedious.

A useful option for me is to skip the content of binary files.

I have adjusted it so that in place of the binary file I put the message: "binary content skipped". That could be something else.