### PR TITLE
Pin Python Docker image patch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.14.4-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
Pins the Docker base image from python:3.14-slim to python:3.14.4-slim.\n\nValidation:\n- docker manifest inspect python:3.14.4-slim